### PR TITLE
add disabled attributes

### DIFF
--- a/demo/src/Menus/index.js
+++ b/demo/src/Menus/index.js
@@ -26,6 +26,11 @@ export function demoPrimaryNav() {
         name: 'Menu Item 4',
         to: '/admin/menu-item-4',
       },
+      {
+        name: 'Disabled Menu',
+        to: '/admin/menu-item-5',
+        disabled: true,
+      },
     ],
   };
 

--- a/src/AppNav.js
+++ b/src/AppNav.js
@@ -9,6 +9,7 @@ type Props = {
       {
         name: string,
         to: string,
+        disabled?: boolean
       },
     ],
     navLabels: {
@@ -47,6 +48,7 @@ export default class AppNav extends Component<Props, State> {
             to={item.to}
             activeClassName="active"
             tag={RRNavLink}
+            disabled={item.disabled === true}
           >
             {item.name}
           </NavLink>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -3827,7 +3827,7 @@ input[type="button"].btn-block {
   margin-bottom: 1rem; }
 
 .card-subtitle {
-  margin-top: 0;
+  margin-top: -0.5rem;
   margin-bottom: 0; }
 
 .card-text:last-child {


### PR DESCRIPTION
We want to use the `NavItems` component like the following example.

```
const items = {
  navLabels: {
    name: '',
  },
  navItems: [
    {
      name: 'Sites',
      to: '/admin/sites',
    },
    {
      name: 'Organizations',
      to: '/admin/organizations',
      disabled: true
    },
    {
      name: 'Account',
      to: '/admin/accounts',
    },
    {
      name: 'Support',
      to: '/admin/support',
    },
  ],
};
return <NavItems items={items} />;
```

## Expected
The `Organization` link button should be disabled.

## Actual
The `Organization` link button is **not** disabled.

Plz merge and release it.
