### PR TITLE
fix: ignore unuse files on npm publish package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+.storybook/
+demo/
+node_modules/
+src/
+stories/
+tests/
+.eslint*
+.gitignore
+.travis.yml
+nwb.*
+tsconfig.json
+yarn*


### PR DESCRIPTION
Our published package has several unused files.
`src` is un-necessary, and `node_modules` too.

```
% tree node_modules/dc-pattern-lib -L 1
node_modules/dc-pattern-lib
├── README.md
├── es
├── lib
├── node_modules
├── package.json
├── src
└── umd
```

So, we have to ignore these unused files.